### PR TITLE
Fix/actp 283/bundling issue under windows

### DIFF
--- a/lib/amdResolve.js
+++ b/lib/amdResolve.js
@@ -25,6 +25,7 @@
 
 const glob = require('glob');
 const path = require('path');
+const url = require('url');
 
 /**
  * White-list of the supported modules types, and their specificity
@@ -86,7 +87,7 @@ module.exports = function resolve(pattern, {
 
     //if the pattern doesn't include star, we don't expand it
     if(!/\*/.test(pattern)){
-        return Promise.resolve([pattern]);
+        return Promise.resolve([url.resolve(pattern, '')]);
     }
 
     const {fileExtension, amdLoader, addFileExtension} = supportedModuleTypes[type];
@@ -178,7 +179,7 @@ module.exports = function resolve(pattern, {
                         //finally add back the loader prefix
                         moduleName = `${amdLoader}${moduleName}`;
 
-                        return moduleName;
+                        return url.resolve(moduleName, '');
                     })
             );
         });

--- a/lib/amdResolve.js
+++ b/lib/amdResolve.js
@@ -87,6 +87,7 @@ module.exports = function resolve(pattern, {
 
     //if the pattern doesn't include star, we don't expand it
     if(!/\*/.test(pattern)){
+        // pass the module name through url.resolve to ensure consistency in path separators (fix for Windows)
         return Promise.resolve([url.resolve(pattern, '')]);
     }
 
@@ -179,6 +180,7 @@ module.exports = function resolve(pattern, {
                         //finally add back the loader prefix
                         moduleName = `${amdLoader}${moduleName}`;
 
+                        // pass the module name through url.resolve to ensure consistency in path separators (fix for Windows)
                         return url.resolve(moduleName, '');
                     })
             );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/grunt-tao-bundle",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/grunt-tao-bundle",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Bundle client side code in TAO extensions",
   "author": "Bertrand Chevrier <bertrand@taotesting.com>",
   "keywords": [


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/ACTP-283

When developing under Windows, we cannot bundle the assets since the bundler task is raising the error:
```
>> Error: SyntaxError: Invalid Unicode escape sequence
>>     at C:\xampp\apps\tao\tao\views\build\node_modules\requirejs\bin\r.js:27738:40
Fatal error: Unable to bundle your code
```

The reason why is the `amdResolver` is mixing both `/` and `\` in the produced URI: `C:/xampp/apps/tao/tao/views/build/output/ui\uploader.js`

The proposed fix filters the produced URI through `url.resolve()` to make sure only `/` is used to separate the path elements.

How to test:
- under a *nix machine, make sure the bundling is working well by running a bundling task
- under a windows machine, with the TAO dev stack, run a bundling task.

example:
```
cd tao/views/build
npx grunt taobundle
```

You can load the companion PR to update your TAO environment: https://github.com/oat-sa/tao-core/pull/2386
