### PR TITLE
Feature/inv 187/exclude nested modules from bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ grunt.initConfig({
 | `bundle.default` | `Boolean` | When `true`, the bundle will include the modules from `amd.default` (Default : `false`) | The current bundle |  |
 | `bundle.include` | `String[]` | A list of additional module to add to the bundle, especially when modules are not in the correct folder. | The current bundle | `['taoQtiItem/qtiCommonRenderer/**/*']`  |
 | `bundle.exclude` | `String[]` | A list of additional module to exclude from the bundle, but if module has nested dependencies that are part of the built file | The current bundle | `['taoQtiItem/qtiItem/test/**/*']`  |
-| `bundle.excludeNested` | `String[]` | A list of module to exclude from the bundle | The current bundle | `['taoQtiItem/qtiItem/test/**/*']`  |
+| `bundle.excludeNested` | `String[]` | A list of module to exclude from the bundle. Excludes all nested dependencies from the built file | The current bundle | `['taoQtiItem/qtiItem/test/**/*']`  |
 | `bundle.dependencies` | `String[]` | Override the extension dependency loading : if set, loads the exact list of module| The current bundle | `['taoQtiItem/loader/taoQtiItemRunner.min']`  |
 | `bundle.babel` | `Boolean` | *Experimental* When `true`, the bundle will use Babel to transpile the code (Default : `false`) | The current bundle |  |
 | `bundle.uglify` | `Boolean` | When `true`, the bundle will be minimified (Default : `true`) | The current bundle |  |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ grunt.initConfig({
 | `bundle.entryPoint` | `String` | Define an entryPoint for the bundle. Useful to create a separate bundle for a given entryPoint| The current bundle | `'controller/login'`  |
 | `bundle.default` | `Boolean` | When `true`, the bundle will include the modules from `amd.default` (Default : `false`) | The current bundle |  |
 | `bundle.include` | `String[]` | A list of additional module to add to the bundle, especially when modules are not in the correct folder. | The current bundle | `['taoQtiItem/qtiCommonRenderer/**/*']`  |
-| `bundle.exclude` | `String[]` | A list of additional module to exclude from the bundle. | The current bundle | `['taoQtiItem/qtiItem/test/**/*']`  |
+| `bundle.exclude` | `String[]` | A list of additional module to exclude from the bundle, but if module has nested dependencies that are part of the built file | The current bundle | `['taoQtiItem/qtiItem/test/**/*']`  |
+| `bundle.excludeNested` | `String[]` | A list of module to exclude from the bundle | The current bundle | `['taoQtiItem/qtiItem/test/**/*']`  |
 | `bundle.dependencies` | `String[]` | Override the extension dependency loading : if set, loads the exact list of module| The current bundle | `['taoQtiItem/loader/taoQtiItemRunner.min']`  |
 | `bundle.babel` | `Boolean` | *Experimental* When `true`, the bundle will use Babel to transpile the code (Default : `false`) | The current bundle |  |
 | `bundle.uglify` | `Boolean` | When `true`, the bundle will be minimified (Default : `true`) | The current bundle |  |

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -218,6 +218,7 @@ module.exports = async function bundler({
 
         bundleConfig.include        = Array.from(includes);
         bundleConfig.excludeShallow = Array.from(excludes);
+        bundleConfig.exclude        = bundle.excludeNested;
 
         //add artificial define to trigger the load of the dependencies
         const loadBundle = [];
@@ -432,7 +433,7 @@ module.exports = async function bundler({
         optimize:                'none',
         preserveLicenseComments: true,
         removeCombined:          false,
-        findNestedDependencies:  true,
+        findNestedDependencies:   true,
         skipDirOptimize:         false,
         optimizeCss:             'none',
         buildCss:                false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/grunt-tao-bundle",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/grunt-tao-bundle",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Bundle client side code in TAO extensions",
   "author": "Bertrand Chevrier <bertrand@taotesting.com>",
   "keywords": [

--- a/test/bundler_spec.js
+++ b/test/bundler_spec.js
@@ -298,14 +298,6 @@ describe('bundler', () => {
     });
 
     it('should exclude nested modules and packages from bundle', async () => {
-        /**
-         * Dependencies:
-         * 
-         * 'ctrl/router' -> ['ctrl/a', 'ctrl/b']
-         * 'ctrl/a' -> 'component/a' -> 'package'
-         * 'ctrl/b' 
-         */
-
         const results = await bundler({
             ...options,
             extension: 'extG',

--- a/test/bundler_spec.js
+++ b/test/bundler_spec.js
@@ -296,4 +296,92 @@ describe('bundler', () => {
             'extF/controller/a.js'
         ]);
     });
+
+    it('should exclude nested modules and packages from bundle', async () => {
+        /**
+         * Dependencies:
+         * 
+         * 'ctrl/router' -> ['ctrl/a', 'ctrl/b']
+         * 'ctrl/a' -> 'component/a' -> 'package'
+         * 'ctrl/b' 
+         */
+
+        const results = await bundler({
+            ...options,
+            extension: 'extG',
+            packages: [
+                {
+                    name: 'packages',
+                    location: 'test/data/packages/',
+                    main: 'main.js'
+                }
+            ],
+            bundles: [
+                {
+                    name: 'extension',
+                    default: true,
+                },
+                {
+                    name: 'extensionExcludeNested',
+                    default: true,
+                    babel: true,
+                    excludeNested: ['extG/controller/a']
+                },
+                {
+                    name: 'extensionExcludeShallow',
+                    default: true,
+                    babel: true,
+                    exclude: ['extG/controller/a']
+                },
+                {
+                    name: 'controllerA',
+                    entryPoint: 'extG/controller/a',
+                    babel: true
+                },
+                {
+                    name: 'controllerAExcludeNested',
+                    entryPoint: 'extG/controller/a',
+                    excludeNested: ['extG/component/a']
+                },
+            ]
+        });
+
+        expect(results).to.be.an('array');
+        expect(results.length).to.be.equal(5);
+        expect(results[0].title).to.be.equal('extG/loader/extension.bundle.js');
+        expect(results[1].title).to.be.equal('extG/loader/extensionExcludeNested.bundle.js');
+        expect(results[2].title).to.be.equal('extG/loader/extensionExcludeShallow.bundle.js');
+        expect(results[3].title).to.be.equal('extG/loader/controllerA.bundle.js');
+        expect(results[4].title).to.be.equal('extG/loader/controllerAExcludeNested.bundle.js');
+        
+        expect(results[0].content).to.be.deep.equal([
+            path.resolve('./test/data/packages/main.js'),
+            'extG/component/a.js',
+            'extG/controller/a.js',
+            'extG/controller/b.js',
+            'extG/controller/routes.js'
+        ], 'Bundle extension must include all modules and packages');
+
+        expect(results[1].content).to.be.deep.equal([
+            'extG/controller/b.js',
+            'extG/controller/routes.js'
+        ], 'Bundle extensionExcludeNested must exclude all modules and packages');
+
+        expect(results[2].content).to.be.deep.equal([
+            path.resolve('./test/data/packages/main.js'),
+            'extG/component/a.js',
+            'extG/controller/b.js',
+            'extG/controller/routes.js',
+        ], 'Bundle extensionExcludeShallow must exclude extG/controller/a but must contains controller\'s nested dependencies');
+
+        expect(results[3].content).to.be.deep.equal([
+            path.resolve('./test/data/packages/main.js'),
+            'extG/component/a.js',
+            'extG/controller/a.js',
+        ], 'Bundle for controller A must include all nested dependencies');
+
+        expect(results[4].content).to.be.deep.equal([
+            'extG/controller/a.js',
+        ], 'Bundle for controller A must exclude all nested dependencies');
+    });
 });

--- a/test/data/extG/views/js/component/a.js
+++ b/test/data/extG/views/js/component/a.js
@@ -1,0 +1,4 @@
+define(['packages'], function(packages){
+  'use strict'
+  return 'Component A is depend on packages'
+});

--- a/test/data/extG/views/js/controller/a.js
+++ b/test/data/extG/views/js/controller/a.js
@@ -1,0 +1,3 @@
+define(['extG/component/a'], function(component){
+    return 'Controller A is required component A'
+});

--- a/test/data/extG/views/js/controller/b.js
+++ b/test/data/extG/views/js/controller/b.js
@@ -1,0 +1,4 @@
+define(['extG/component/a'], function(component){
+  'use strict'
+  return 'Controller B is required component A';
+});

--- a/test/data/extG/views/js/controller/routes.js
+++ b/test/data/extG/views/js/controller/routes.js
@@ -1,0 +1,9 @@
+define(['extG/controller/a', 'extG/controller/b'], function (ctrlA, ctrlB) {
+  'use strict';
+  const router = {
+      '/a': ctrlA,
+      '/b': ctrlB
+  }
+
+  return router;
+});


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/INV-187
**Description:** Add option `excludeNested` for exclude nested modules and packages from the bundle.
**Unit tests cli:** `npm run test`
**Dependent** 
- [For bundle buildng in QTI test](https://github.com/oat-sa/extension-tao-testqti/pull/1869)