### PR TITLE
Feature/TR-6832/Bundler pre-transform for modern syntax

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ jobs:
     code-check:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
               with:
                   token: ${{ secrets.GH_TOKEN }}
             - run: git fetch --tags --unshallow
@@ -20,7 +20,7 @@ jobs:
               uses: oat-sa/conventional-commit-action@v0
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v4
               with:
                   node-version: 18.x
                   registry-url: https://registry.npmjs.org
@@ -34,10 +34,10 @@ jobs:
               run: npm run coverage:clover
             - name: Report coverage
               if: always()
-              uses: slavcodev/coverage-monitor-action@1.1.0
+              uses: slavcodev/coverage-monitor-action@398c4cbbb710e549a8407fdef96ae8b9454d0463
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
-                  clover_file: coverage/clover.xml
+                  coverage_path: coverage/clover.xml
                   threshold_alert: 75
                   threshold_warning: 90
                   comment_mode: update
@@ -47,7 +47,7 @@ jobs:
             - name: Annotate Code Linting Results
               if: always()
               continue-on-error: true
-              uses: ataylorme/eslint-annotate-action@1.2.0
+              uses: ataylorme/eslint-annotate-action@d57a1193d4c59cbfbf3f86c271f42612f9dbd9e9
               with:
-                  repo-token: '${{ secrets.GITHUB_TOKEN }}'
+                  GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
                   report-json: 'eslint_report.json'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ In order to create bundles that doesn't impact the extension dependency model, w
 This task produce bundles sandboxed to a given extension.
 
 The task is made of 2 steps :
+
 1. The bundling, based on the configuration, we aggregate the assets of the extension, into a single file. Since the TAO client source code is managed using AMD modules and use some [requirejs](https://requirejs.org) internals, we use the [r.js](https://requirejs.org/docs/optimization.html) optimizer to parse the dependency tree and bundle the assets. We don't use it to minimify the resources.
 2. The transform step is used to either transpile the code, using [Babel 7](https://babeljs.io/) (still experimental) or [UglifyJs](http://lisperator.net/uglifyjs/) to compress and minimify it.
 
@@ -18,7 +19,7 @@ The task is made of 2 steps :
 
 ## Getting Started
 
-This plugin requires [node.js >= 8.6.0](https://nodejs.org/en/download/) and to be installed along with  [Grunt](http://gruntjs.com/).
+This plugin requires [node.js >= 18.0.0](https://nodejs.org/en/download/) and to be installed along with [Grunt](http://gruntjs.com/).
 To add install it :
 
 ```shell
@@ -28,6 +29,7 @@ npm install @oat-sa/grunt-tao-bundle --save-dev
 ## The "tao-bundle" task
 
 ### Overview
+
 In your project's Gruntfile, add a section named `bundle` to the data object passed into `grunt.initConfig()` or `grunt.config.merge()`.
 
 ```js
@@ -54,45 +56,49 @@ grunt.initConfig({
 
 ## Options
 
-| Option                 | Type              | Description                                                                                                                                                                                  | Scope | Example value                                                                                             |
-|------------------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|-----------------------------------------------------------------------------------------------------------|
-| `amd`                  | `Object`          | The AMD/requirejs configuration                                                                                                                                                              |  All extensions, all bundles |                                                                                                           |
-| `amd.baseUrl`          | `String`          | Relative path to resolve the AMD modules                                                                                                                                                     | All extensions, all bundles | `../js`                                                                                                   |
-| `amd.paths`            | `Object`          | The list of AMD paths/alias                                                                                                                                                                  | All extensions, all bundles |                                                                                                           |
-| `amd.shim`             | `Object`          | the AMD shim configuration                                                                                                                                                                   | All extensions, all bundle |                                                                                                           |
-| `amd.vendor`           | `String[]`        | A list of vendor modules                                                                                                                                                                     | All extensions, all bundle | `['lodash', 'core/**/*']`                                                                                 |
-| `amd.exclude`          | `String[]`        | A list of modules to always exclude                                                                                                                                                          | All extensions, all bundle | `['mathJax', 'ckeditor']`                                                                                 |
-| `amd.bootstrap`        | `String[]`        | A list of module to include to bootstrap a bundle                                                                                                                                            | All extensions, all bundle | `['loader/bootrstrap']`                                                                                   |
-| `amd.default`          | `String[]`        | A list of modules to include for _default_ bundles. It's the default pattern for TAO extension source code.                                                                                  | All extensions, all bundle | `['controller/**/*', 'component/**/*', 'provider/**/*']`                                                  |
-| `paths`                | `Object`          | Additional list of paths/alias                                                                                                                                                               | The current extension  |                                                                                                           |
-| `workDir`              | `String`          | The temporary working directory to copy the sources and generates the bundles                                                                                                                | The current extension | `output`                                                                                                  |
-| `outputDir`            | `String`          | The directory (inside the workDir) where the bundles will be generated                                                                                                                       | The current extension | `loader`                                                                                                  |
-| `extension`            | `String`          | The name of the current extension                                                                                                                                                            | The current extension | `taoQtiTest`                                                                                              |
-| `rootExtension`        | `String`          | The name of the root extension (the one with no prefix in AMD and that contains the libs and SDK)                                                                                            | All extensions | `tao`                                                                                                     |
-| `dependencies`         | `String[]`        | The list of **extension** dependencies, the code from a dependency is excluded from the bundle.                                                                                              | The current extensions | `['taoItems', 'taoTests', 'taoQtiItem']`                                                                  |
-| `allowExternal`        | `String[]`        | Allow external dependency into the bundle. It's not a good practice, but this can be used for aliases. Allow them to be included without the bundler to warn you about forbidden dependency. | The current extensions | `['qtiInfoControlContext']`                                                                               |
-| `getExtensionPath`     | `Function`        | A function that resolves the path to the JS files from an extension                                                                                                                          | All extensions | `extension => root + '/' + extension + '/views/js' `                                                      |
-| `getExtensionCssPath`  | `Function`        | A function that resolves the path to the CSS files from an extension                                                                                                                         | All extensions | `extension => root + '/' + extension + '/views/css' `                                                     |
-| `bundles`              | `Object[]`        | The bundles configuration                                                                                                                                                                    | The current extensions |                                                                                                           |
-| `bundle.name`          | `String`          | The bundle name without the file extension                                                                                                                                                   | The current bundle | `vendor` or `taoQtiTest`                                                                                  |
-| `bundle.vendor`        | `Boolean`         | When `true`, the bundle will include *ONLY* the libraries from `amd.vendor` (Default : `false`)                                                                                              | The current bundle |                                                                                                           |
-| `bundle.standalone`    | `Boolean`         | When `true`, the bundle will include *ALL* dependencies so that it can be run as a standalone (Default : `false`)                                                                            | The current bundle |                                                                                                           |
-| `bundle.bootstrap`     | `Boolean`         | When `true`, the bundle will include the modules from `amd.bootstrap` (Default : `false`)                                                                                                    | The current bundle |                                                                                                           |
-| `bundle.entryPoint`    | `String`          | Define an entryPoint for the bundle. Useful to create a separate bundle for a given entryPoint                                                                                               | The current bundle | `'controller/login'`                                                                                      |
-| `bundle.default`       | `Boolean`         | When `true`, the bundle will include the modules from `amd.default` (Default : `false`)                                                                                                      | The current bundle |                                                                                                           |
-| `bundle.include`       | `String[]`        | A list of additional module to add to the bundle, especially when modules are not in the correct folder.                                                                                     | The current bundle | `['taoQtiItem/qtiCommonRenderer/**/*']`                                                                   |
-| `bundle.exclude`       | `String[]`        | A list of additional module to exclude from the bundle, but if module has nested dependencies that are part of the built file                                                                | The current bundle | `['taoQtiItem/qtiItem/test/**/*']`                                                                        |
-| `bundle.excludeNested` | `String[]`        | A list of module to exclude from the bundle. Excludes all nested dependencies from the built file                                                                                            | The current bundle | `['taoQtiItem/qtiItem/test/**/*']`                                                                        |
-| `bundle.dependencies`  | `String[]`        | Override the extension dependency loading : if set, loads the exact list of module                                                                                                           | The current bundle | `['taoQtiItem/loader/taoQtiItemRunner.min']`                                                              |
-| `bundle.babel`         | `Boolean`         | *Experimental* When `true`, the bundle will use Babel to transpile the code (Default : `false`)                                                                                              | The current bundle |                                                                                                           |
-| `bundle.targets`       | `Object`,`String` | *Experimental* A specific target for transpiling the code when using Babel (Default : `'extends @oat-sa/browserslist-config-tao'`)                                                           | The current bundle | `{ ie: '11' }`                                                                                            |
-| `bundle.uglify`        | `Boolean`         | When `true`, the bundle will be minimified (Default : `true`)                                                                                                                                | The current bundle |                                                                                                           |
-| `bundle.package`       | `Object[]`        | Extends [packages](https://requirejs.org/docs/api.html#packages) to the bundle (Default : `[]`)                                                                                              | The current bundle | `[{ name: 'codemirror', location: '../../../tao/views/node_modules/codemirror', main: 'lib/codemirror'}]` 
+| Option                      | Type              | Description                                                                                                                                                                                  | Scope | Example value                                                                                                          |
+|-----------------------------|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|------------------------------------------------------------------------------------------------------------------------|
+| `amd`                       | `Object`          | The AMD/requirejs configuration                                                                                                                                                              |  All extensions, all bundles |                                                                                                 |
+| `amd.baseUrl`               | `String`          | Relative path to resolve the AMD modules                                                                                                                                                     | All extensions, all bundles | `../js`                                                                                          |
+| `amd.paths`                 | `Object`          | The list of AMD paths/alias                                                                                                                                                                  | All extensions, all bundles |                                                                                                  |
+| `amd.shim`                  | `Object`          | the AMD shim configuration                                                                                                                                                                   | All extensions, all bundle |                                                                                                   |
+| `amd.vendor`                | `String[]`        | A list of vendor modules                                                                                                                                                                     | All extensions, all bundle | `['lodash', 'core/**/*']`                                                                         |
+| `amd.exclude`               | `String[]`        | A list of modules to always exclude                                                                                                                                                          | All extensions, all bundle | `['mathJax', 'ckeditor']`                                                                         |
+| `amd.bootstrap`             | `String[]`        | A list of module to include to bootstrap a bundle                                                                                                                                            | All extensions, all bundle | `['loader/bootrstrap']`                                                                           |
+| `amd.default`               | `String[]`        | A list of modules to include for _default_ bundles. It's the default pattern for TAO extension source code.                                                                                  | All extensions, all bundle | `['controller/**/*', 'component/**/*', 'provider/**/*']`                                          |
+| `paths`                     | `Object`          | Additional list of paths/alias                                                                                                                                                               | The current extension  |                                                                                                       |
+| `workDir`                   | `String`          | The temporary working directory to copy the sources and generates the bundles                                                                                                                | The current extension | `output`                                                                                               |
+| `outputDir`                 | `String`          | The directory (inside the workDir) where the bundles will be generated                                                                                                                       | The current extension | `loader`                                                                                               |
+| `extension`                 | `String`          | The name of the current extension                                                                                                                                                            | The current extension | `taoQtiTest`                                                                                           |
+| `rootExtension`             | `String`          | The name of the root extension (the one with no prefix in AMD and that contains the libs and SDK)                                                                                            | All extensions | `tao`                                                                                                         |
+| `dependencies`              | `String[]`        | The list of **extension** dependencies, the code from a dependency is excluded from the bundle.                                                                                              | The current extensions | `['taoItems', 'taoTests', 'taoQtiItem']`                                                              |
+| `allowExternal`             | `String[]`        | Allow external dependency into the bundle. It's not a good practice, but this can be used for aliases. Allow them to be included without the bundler to warn you about forbidden dependency. | The current extensions | `['qtiInfoControlContext']`                                                                           |
+| `getExtensionPath`          | `Function`        | A function that resolves the path to the JS files from an extension                                                                                                                          | All extensions | `extension => root + '/' + extension + '/views/js' `                                                          |
+| `getExtensionCssPath`       | `Function`        | A function that resolves the path to the CSS files from an extension                                                                                                                         | All extensions | `extension => root + '/' + extension + '/views/css' `                                                         |
+| `babelPreTransform`         | `Object`          | If given, the options for the Babel pre-transform of the sources before bundling                                                                                                             | All extensions, all bundles | `{ enabled: true, exclude: ['mathjax'] }`                                                        |
+| `babelPreTransform.enabled` | `Boolean`         | If true, the sources are pre-transformed with Babel before bundling                                                                                                                          | All extensions, all bundles |                                                                                                  |
+| `babelPreTransform.exclude` | `String[]`        | List of module names to exclude from the Babel pre-transform                                                                                                                                 | All extensions, all bundles |                                                                                                  |
+| `bundles`                   | `Object[]`        | The bundles configuration                                                                                                                                                                    | The current extensions |                                                                                                       |
+| `bundle.name`               | `String`          | The bundle name without the file extension                                                                                                                                                   | The current bundle | `vendor` or `taoQtiTest`                                                                                  |
+| `bundle.vendor`             | `Boolean`         | When `true`, the bundle will include *ONLY* the libraries from `amd.vendor` (Default : `false`)                                                                                              | The current bundle |                                                                                                           |
+| `bundle.standalone`         | `Boolean`         | When `true`, the bundle will include *ALL* dependencies so that it can be run as a standalone (Default : `false`)                                                                            | The current bundle |                                                                                                           |
+| `bundle.bootstrap`          | `Boolean`         | When `true`, the bundle will include the modules from `amd.bootstrap` (Default : `false`)                                                                                                    | The current bundle |                                                                                                           |
+| `bundle.entryPoint`         | `String`          | Define an entryPoint for the bundle. Useful to create a separate bundle for a given entryPoint                                                                                               | The current bundle | `'controller/login'`                                                                                      |
+| `bundle.default`            | `Boolean`         | When `true`, the bundle will include the modules from `amd.default` (Default : `false`)                                                                                                      | The current bundle |                                                                                                           |
+| `bundle.include`            | `String[]`        | A list of additional module to add to the bundle, especially when modules are not in the correct folder.                                                                                     | The current bundle | `['taoQtiItem/qtiCommonRenderer/**/*']`                                                                   |
+| `bundle.exclude`            | `String[]`        | A list of additional module to exclude from the bundle, but if module has nested dependencies that are part of the built file                                                                | The current bundle | `['taoQtiItem/qtiItem/test/**/*']`                                                                        |
+| `bundle.excludeNested`      | `String[]`        | A list of module to exclude from the bundle. Excludes all nested dependencies from the built file                                                                                            | The current bundle | `['taoQtiItem/qtiItem/test/**/*']`                                                                        |
+| `bundle.dependencies`       | `String[]`        | Override the extension dependency loading : if set, loads the exact list of module                                                                                                           | The current bundle | `['taoQtiItem/loader/taoQtiItemRunner.min']`                                                              |
+| `bundle.babel`              | `Boolean`         | *Experimental* When `true`, the bundle will use Babel to transpile the code (Default : `false`)                                                                                              | The current bundle |                                                                                                           |
+| `bundle.targets`            | `Object`,`String` | *Experimental* A specific target for transpiling the code when using Babel (Default : `'extends @oat-sa/browserslist-config-tao'`)                                                           | The current bundle | `{ ie: '11' }`                                                                                            |
+| `bundle.uglify`             | `Boolean`         | When `true`, the bundle will be minimified (Default : `true`)                                                                                                                                | The current bundle |                                                                                                           |
+| `bundle.package`            | `Object[]`        | Extends [packages](https://requirejs.org/docs/api.html#packages) to the bundle (Default : `[]`)                                                                                              | The current bundle | `[{ name: 'codemirror', location: '../../../tao/views/node_modules/codemirror', main: 'lib/codemirror'}]` |
 
 ### Examples
 
 The configuration from the `tao` extension :
-```
+
+```js
 grunt.config.merge({
     bundle : {
         //define the global options for all extensions' tasks
@@ -108,6 +114,7 @@ grunt.config.merge({
         tao : {
             options : {
                 extension : 'tao',
+                babelPreTransform: { enabled: true },
                 bundles : [{
                     //bundles sources from amd.vendor
                     name   : 'vendor',
@@ -132,7 +139,8 @@ grunt.config.merge({
 ```
 
 The configuration from the `taoQtiItem` extension :
-```
+
+```js
 grunt.config.merge({
     bundle : {
         taoqtiitem : {
@@ -145,6 +153,7 @@ grunt.config.merge({
                     'qtiCustomInteractionContext' : `${root}/taoQtiItem/views/js/runtime/qtiCustomInteractionContext`,
                     'qtiInfoControlContext' : `${root}taoQtiItem/views/js/runtime/qtiInfoControlContext`
                 },
+                babelPreTransform: { enabled: true, exclude: ['mathjax'] },
 
                 bundles : [{
                     name : 'taoQtiItem',
@@ -170,6 +179,7 @@ grunt.config.merge({
     }
 });
 ```
+
 ## Test
 
 ```sh
@@ -177,7 +187,10 @@ npm test
 ```
 
 ## Release History
- * _0.8.0_ Add options for standalone bundles and specific Babel targets 
+
+ * _1.1.0_ Add babelPreTransform option
+ * _1.0.0_ Upgrade to Node 18
+ * _0.8.0_ Add options for standalone bundles and specific Babel targets
  * _0.7.0_ Update browserslist version (remove IE11 support)
  * _0.6.1_ Enable babel updates
  * _0.6.0_ Exclude nested modules from bundle

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -26,6 +26,7 @@ const requirejs = require('requirejs');
 const path = require('path');
 const fs = require('fs-extra');
 const amdResolve = require('./amdResolve.js');
+const babel = require('@babel/core');
 
 /*
  * Creates bundles from the given configuration
@@ -49,6 +50,7 @@ module.exports = async function bundler({
     extension = '',
     rootExtension = '',
     bundles = [],
+    babelPreTransform = { enabled: false },
     dependencies = [],
     getExtensionPath = () => {},
     getExtensionCssPath = () => {},
@@ -451,7 +453,34 @@ module.exports = async function bundler({
         shim: amd.shim,
         dir: workDir,
         modules: rJsModules,
-        packages: rJsPackages
+        packages: rJsPackages,
+        onBuildRead: function (moduleName, path, contents) {
+            if (!babelPreTransform?.enabled) {
+                return contents;
+            }
+            const isExcluded = babelPreTransform.exclude?.some(pattern => moduleName.includes(pattern));
+            if (path.endsWith('.js') && !isExcluded) {
+                // Babel pre-transform is invoked on file read,
+                // because rJs optimizer cannot parse many ES2015+ syntaxes.
+                try {
+                    const result = babel.transformSync(contents, {
+                        presets: [
+                            ['@babel/preset-env', {
+                                targets: { esmodules: true } // this target offers a good balance between syntax support and bundle size
+                            }]
+                        ],
+                        sourceType: 'script',
+                        compact: false,
+                        comments: false
+                    });
+                    return result.code;
+                } catch (err) {
+                    console.warn(`Babel transform failed for ${moduleName}:`, err);
+                    return contents;  // fallback to original on error
+                }
+            }
+            return contents;
+        },
     };
 
     const isPackage = module => {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "coverage:clover": "nyc report --reporter=clover"
     },
     "engine": {
-        "node": ">=14.14"
+        "node": ">=18"
     },
     "repository": {
         "type": "git",

--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018-2019 (original work) Open Assessment Technlogies SA
+ * Copyright (c) 2018-2026 (original work) Open Assessment Technlogies SA
  *
  */
 
@@ -49,6 +49,9 @@ module.exports = function (grunt) {
          * @param {bundle[]} bundles - the configuration per bundle
          * @param {String[]} dependencies - the list of the dependencies (code from dependencies is excluded)
          * @param {String[]} [allowExternal] - the list of modules allowed to be included, mostly for internal aliases
+         * @param {Object} [babelPreTransform] - if given, the options for the Babel pre-transform of the sources before bundling
+         * @param {Boolean} [babelPreTransform.enabled = false] - if true, the sources are pre-transformed with Babel before bundling
+         * @param {String[]} [babelPreTransform.exclude = []] - list of module names to exclude from the Babel pre-transform
          */
 
         /**
@@ -74,7 +77,8 @@ module.exports = function (grunt) {
         const options = this.options();
 
         try {
-            grunt.log.subhead('Start bundling');
+            const startMessage = options.babelPreTransform?.enabled ? 'Start bundling with pre-transform' : 'Start bundling';
+            grunt.log.subhead(startMessage);
 
             const results = await bundler(options);
 

--- a/test/bundler_spec.js
+++ b/test/bundler_spec.js
@@ -345,7 +345,7 @@ describe('bundler', () => {
         expect(results[2].title).to.be.equal('extG/loader/extensionExcludeShallow.bundle.js');
         expect(results[3].title).to.be.equal('extG/loader/controllerA.bundle.js');
         expect(results[4].title).to.be.equal('extG/loader/controllerAExcludeNested.bundle.js');
-        
+
         expect(results[0].content).to.be.deep.equal([
             path.resolve('./test/data/packages/main.js'),
             'extG/component/a.js',
@@ -375,5 +375,43 @@ describe('bundler', () => {
         expect(results[4].content).to.be.deep.equal([
             'extG/controller/a.js',
         ], 'Bundle for controller A must exclude all nested dependencies');
+    });
+
+    it('should pre-transform modern syntax using babel (which rjs alone cannot)', async () => {
+        const results = await bundler( {
+            ...options,
+            extension : 'extH',
+            babelPreTransform: { enabled: true },
+            bundles : [{
+                name : 'extH',
+                default: true
+            }]
+        });
+
+        expect(results).to.be.an('array');
+        expect(results.length).to.be.equal(1);
+        expect(results[0].title).to.be.equal('extH/loader/extH.bundle.js');
+        expect(results[0].content).to.be.deep.equal([
+            'extH/controller/modernSyntax.js',
+        ]);
+    });
+
+    it('should throw on modern syntax if babel pre-transform skipped', async () => {
+        try {
+            await bundler( {
+                ...options,
+                extension : 'extH',
+                babelPreTransform: { enabled: false },
+                bundles : [{
+                    name : 'extH',
+                    default: true
+                }]
+            });
+            expect(false, 'Bundler should have thrown already!').to.be.true;
+        }
+        catch (e) {
+            expect(e).to.be.an.instanceof(Error);
+            expect(e.message).to.match(/Parse error using esprima/);
+        }
     });
 });

--- a/test/data/extH/views/js/controller/modernSyntax.js
+++ b/test/data/extH/views/js/controller/modernSyntax.js
@@ -1,0 +1,78 @@
+/* eslint-disable */
+define([], function () {
+    'use strict';
+
+    // ES2015
+    // Arrow functions
+    const add = (a, b) => a + b;
+
+    // Class
+    class CustomDOMElement extends HTMLElement {}
+
+    // Template literals
+    const greeting = `Hello, ${name}!`;
+
+    // Destructuring
+    const [first, second] = [1, 2];
+
+    // ES2016
+    // Exponentiation operator
+    let x = 10 ** 2;
+    x **= 3;
+
+    // esprima 4 parsing support ends around here
+
+    // ES2018
+    // Object rest/spread
+    const obj1 = { a: 1, b: 2, c: 3 };
+    const { a, ...rest } = obj1;
+
+    // Named capture groups in regex
+    let regex = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/;
+    let match = regex.exec('2024-06-01');
+
+    // ES2019
+    // Optional catch binding
+    try {
+        throw new Error('Test');
+    } catch {
+        doSomething();
+    }
+
+    // ES2020
+    // Dynamic import - not strictly compatible with AMD modules anyway?
+    import('./dynamicModule.js').then(module => {
+        console.log('Dynamic module loaded:', module);
+    }).catch(err => {
+        console.error('Failed to load dynamic module:', err);
+    });
+
+    // Optional chaining
+    const obj = { a: { b: { c: 42 } } };
+    const obj_c = obj?.a?.b?.c;
+
+    // Nullish coalescing
+    const value = obj.a.b.c ?? 'Default value';
+
+    // ES2021
+    // Logical assignment operators
+    let d, e;
+    d ||= e;
+    obj.a.b ||= d;
+
+    d &&= e;
+    obj.a.b &&= d;
+
+    // Numeric separators
+    let budget = 1_000_000_000_000;
+
+    // ES2025 - not yet supported
+    // Regexp modifiers
+    // regex = /(?i:a)a/;
+
+    // ES2026 - not yet supported
+    // Explicit resource management (hypothetical)
+    // using handlerSync = openSync();
+
+    return {};
+});


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TR-6832

This PR adds a Babel _pre-transform_ step to the bundler, which allows extension sources to use **much more modern syntax** (up to ES2021 - previous limit was roughly ES2016).

Available JS syntax now includes: object rest/spread, named capture groups, optional catch binding, optional chaining, nullish coaslescing, logical assignment, numeric separators.

My solution is a bit strange because it can invoke Babel twice in a single bundling task. But maybe Babel should always have been invoked before rJs optimizer (the weakest parser in the system), instead of after?

- Old flow: sources -> rJs optimizer -> Babel transform for targets -> minify
- New flow: sources -> Babel pre-transform -> rJs optimizer -> Babel transform for targets -> minify

The pre-transform is only enabled by a particular bundle config property.
We don't need to enable it for every single TAO extension - it makes sense for just the ones containing the most JS code and most frequent changes:

List of extension PRs where I plan to use `babelPreTransform: { enabled: true }`:
- https://github.com/oat-sa/tao-core/pull/4426
- https://github.com/oat-sa/extension-tao-item/pull/732
- https://github.com/oat-sa/extension-tao-test/pull/531
- https://github.com/oat-sa/extension-tao-test-runner-plugins/pull/276

List of extension PRs where I plan to use `babelPreTransform: { enabled: true, exclude: ['mathjax'] }`:
- https://github.com/oat-sa/extension-tao-itemqti/pull/2993
- https://github.com/oat-sa/extension-tao-testqti/pull/2780
- https://github.com/oat-sa/extension-tao-clientdiag/pull/352
- https://github.com/oat-sa/extension-tao-proctoring/pull/980
- https://github.com/oat-sa/extension-tao-mediamanager/pull/565
- https://github.com/oat-sa/extension-tao-testqti-previewer/pull/249
- https://github.com/oat-sa/extension-tao-test-preview-ui-loader/pull/307

I've tested Backoffice with these newly generated bundles with `DEBUG_MODE: false`.  Deployed on unit11 for verifications.

The nice thing is that bundle sizes only increase slightly if you use a lot of modern syntaxes (you can copy `modernSyntax.js` into a place like `taoQtiTest/views/js/controller/` and have it automatically bundled).
Around 1% is added in the worst case.

The downside is an increased bundling time, which I can live with.

Capturing bundle modules and bundle sizes for several key extensions, before and after this change:
<img width="1224" height="731" alt="2026-05-06 17 32 13" src="https://github.com/user-attachments/assets/0e7d574b-2551-4750-ac2b-befc56f8a054" />

